### PR TITLE
Added nasId attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ goradius
 Description
 -----------
 
-`goradius` package implements basic Radius client capabilities, allowing Go code ti authenticate against a Radius server.
+`goradius` package implements basic Radius client capabilities, allowing Go code to authenticate against a Radius server.
 It is based on https://github.com/btimby/py-radius python package
 
 Installation
@@ -35,7 +35,7 @@ To authenticate a user simply create a new `AuthenticatorT` object using server 
 
 And try to authenticate a user:
 
-	ok, err := auth.Authenticate(username, password)
+	ok, err := auth.Authenticate(username, password, nasId)
 	if err != nil {
 		panic(err)
 	}

--- a/goradius_test.go
+++ b/goradius_test.go
@@ -3,14 +3,17 @@ package goradius
 import (
 	"encoding/binary"
 	"testing"
+	"time"
 )
 
 var (
 	server   string = ""
 	port     string = "1812"
 	secret   string = ""
+	timeout  time.Duration = 5
 	user     string = ""
 	password string = ""
+	nasId    string = ""
 )
 
 func TestConnection(t *testing.T) {
@@ -48,8 +51,8 @@ func TestRadcrypt(t *testing.T) {
 }
 
 func TestAuth(t *testing.T) {
-	auth := Authenticator(server, port, secret)
-	res, err := auth.Authenticate(user, password)
+	auth := AuthenticatorWithTimeout(server, port, secret, timeout)
+	res, err := auth.Authenticate(user, password, nasId)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Hello Alessando,
I needed the nasId attribute to have grouped RADIUS access to a Windows-AD.
To preserve backward compatibility the attribute won't be sent if the corresponding string is empty.
Please consider to incorporate this pull request.
