### PR TITLE
Fix dial timeout case.

### DIFF
--- a/goradius.go
+++ b/goradius.go
@@ -83,10 +83,10 @@ func (a *AuthenticatorT) Authenticate(username, password, nasID string) (bool, e
 			return a.parseResponse(resp, auth)
 		case err := <-eCh:
 			return false, err
-		case <-time.After(a.timeout * time.Second):
+		case <-time.After(a.timeout):
 		}
 	}
-	return false, fmt.Errorf("Error: Server is not responding: waited %d times %ds for an answer", RETRIES, a.timeout)
+	return false, fmt.Errorf("Error: Server is not responding: waited %d times %v for an answer", RETRIES, a.timeout)
 }
 
 func (a *AuthenticatorT) generateAuthenticator() []byte {


### PR DESCRIPTION
The prior version of goradius used timeout seconds, while the 2017-May-2 version uses time.Duration.  The timeout multiplies that by time.Seconds duration, causing excessively long timeouts.

Fix the timeout case to remove the `* time.Second`. Fix the error message to use the time.Duration String() representation.

Added a unit test for Dial timeout.